### PR TITLE
Sum quantities instead of count in MaxSpecificItem

### DIFF
--- a/ItemPrinterDeGacha.Core/SeedSearch.cs
+++ b/ItemPrinterDeGacha.Core/SeedSearch.cs
@@ -85,7 +85,7 @@ public static class SeedSearch
             foreach (var item in items)
             {
                 if (find.Contains(item.ItemId))
-                    c++;
+                    c += item.Count;
             }
 
             if (c <= count)


### PR DESCRIPTION
The MaxSpecificItem Search Mode currently returns the result with the highest number of rolls returning the target item, rather than the actual quantity. This results in results being reported that don't actually contain the max number of that item. This pull request changes that behavior so that the result with the highest total of the target item is returned instead.

Before: 6 count, 14 total
![](https://i.imgur.com/sKTVea1.png)

After: 4 count, 20 total
![](https://i.imgur.com/oSHUZyv.png)